### PR TITLE
Horizontal bender fix

### DIFF
--- a/gdml/HBender.gdml
+++ b/gdml/HBender.gdml
@@ -5,16 +5,7 @@
  	<constant name="PI" value="1.*pi"/>
 	<variable name="target_to_hbbore_center" value="176"/>
 	<constant name="fBoreRot" value="1.5"/>
-
-	<constant name="fBpipeThick" value="0.3"/>
-	<constant name="fBpipeRMax1" value="2.54"/>
-	<constant name="fBpipeRMin1" value="-fBpipeThick+fBpipeRMax1"/>
-	<constant name="fBpipeRMax2" value="30.48"/>
-	<constant name="fBpipeRMin2" value="-fBpipeThick+fBpipeRMax2"/>
-	<constant name="fBpipeDz" value="115.75"/>
-	<constant name="fHBBpipeCenterX" value="-cos(8.5*pi/180)*sin(5.5*pi/180)*target_to_hbbore_center+2"/>
-	<constant name="fHBBpipeCenterY" value="0"/>
-	<constant name="fHBBpipeCenterZ" value="-sin(8.5*pi/180)*sin(5.5*pi/180)*target_to_hbbore_center+2"/>
+	<constant name="tempOffSet" value="0.5"/>
 
 	<constant name="fHBBoreXfp" value="11.75"/>
 	<constant name="fHBBoreXfn" value="-4.13"/>
@@ -72,20 +63,15 @@
 	<constant name="fHBCryoBoxZ" value="-0.1+fHBBoreZ"/>
 
   	<position name="Origin" unit="cm" x="0" y="0" z="0" />
-  	<position name="pBPipe" unit="cm" x="fHBBpipeCenterX" y="fHBBpipeCenterY" z="fHBBpipeCenterX" />
-   	<position name="pYork" unit="cm" x="-6" y="0" z="0" />
-	
+   	<position name="pYork" unit="cm" x="-6" y="0" z="0" />	
 	<position name="pHBCoilTopCut" unit="cm" x="0" y="fHBCoilWidth+fHBCoilBoxTopCutY/2" z="0" />
   	<position name="pHBCoilBottomCut" unit="cm" x="0" y="-(fHBCoilWidth+fHBCoilBoxTopCutY/2)" z="0" />
-  	<position name="pBpipe" unit="cm" x="-236.65" y="0" z="1469.33" />
-  	<position name="pBpipeInCryo" unit="cm" x="-198.14" y="0" z="1475.34" />
- 
+  
+  
   	<rotation name="identity" x="0" y="0" z="0"/>
 	<rotation name="rHBRot" unit="deg" x="0" y="fBoreRot" z="0"/>
 	<rotation name="rHBCoilLeftRot" unit="deg" x="0" y="-3.0" z="0"/>
 	<rotation name="rHBCoilRightRot" unit="deg" x="0" y="-7.0" z="0"/>
-	<rotation name="rBpipe" unit="deg" x="0" y="8.5" z="0" />
-	<rotation name="rBpipeInCryo" unit="deg" x="0" y="-7.0" z="0" />
 
 </define>
 
@@ -124,9 +110,6 @@
 
 <solids>
  
-	<cone name = "beamPipeFull" rmin1="0" rmax1="fBpipeRMax1" rmin2="0" rmax2="fBpipeRMax2" z="fBpipeDz" startphi="0" deltaphi="360" aunit="deg" lunit= "cm" />
-	<cone name = "beamPipeVac" rmin1="0" rmax1="fBpipeRMin1" rmin2="0" rmax2="fBpipeRMin2" z="fBpipeDz" startphi="0" deltaphi="360" aunit="deg" lunit= "cm" />
-
 	<arb8 lunit="cm" name="HBenderBox" dz="fHBCoilBoxZ/2+15" 
 		v1x="+62.0" v1y="+64.0" 
 		v2x="+62.0" v2y="-64.0"
@@ -137,7 +120,7 @@
              	v7x="-24.0" v7y="-64.0" 
 		v8x="-24.0" v8y="+64.0"/>
 
-	<arb8 lunit="cm" name="hbBore" dz="(fHBBoreZ/2)+0.5" 
+	<arb8 lunit="cm" name="hbBore" dz="(fHBBoreZ/2)" 
 		v1x="fHBBoreXfn" v1y="-fHBBoreY/2" 
 		v2x="fHBBoreXfn" v2y="fHBBoreY/2"
              	v3x="fHBBoreXfp" v3y="fHBBoreY/2" 
@@ -146,7 +129,7 @@
 		v6x="fHBBoreXbn" v6y="fHBBoreY/2"
              	v7x="fHBBoreXbp" v7y="fHBBoreY/2" 
 		v8x="fHBBoreXbp" v8y="-fHBBoreY/2"/>
-
+	
 	<arb8 lunit="cm" name="hbYork" dz="fHBYorkZ/2" 
 		v1x="fHBYorkXfn" v1y="-fHBYorkY/2" 
 		v2x="fHBYorkXfn" v2y="fHBYorkY/2"
@@ -237,21 +220,14 @@
 	<positionref ref="Origin"/>
 	</subtraction>
 
-	<subtraction name="hbCryoBoxHollow">
+	<subtraction name="hbCryoSolid">
 	<first ref="hbCryoBoxFull"/>
 	<second ref="hbCryoBoxCut"/>
 	<positionref ref="Origin"/>
 	</subtraction>
 
-	<subtraction name="hbCryoSolidWithPipeCut">
-	<first ref="hbCryoBoxHollow"/>
-	<second ref="beamPipeFull"/>
-	<positionref ref="pBpipeInCryo"/>
-	<rotationref ref="rBpipeInCryo"/>	
-	</subtraction>
-
 	<subtraction name="hbCryoMinusBore">
-	<first ref="hbCryoSolidWithPipeCut"/>
+	<first ref="hbCryoSolid"/>
 	<second ref="hbBore"/>
 	<positionref ref="Origin"/>
 	</subtraction>
@@ -276,7 +252,7 @@
       <solidref ref="HBYorkSolid"/>
      </volume>
     
-    <volume name="HBCryoBoxLogic">
+     <volume name="HBCryoBoxLogic">
       <materialref ref="SSteel"/>
       <solidref ref="hbCryoMinusBore"/>
        <auxiliary auxtype="SensDet" auxvalue="HBCryoBox"/>

--- a/include/NpolAnalysisManager.hh
+++ b/include/NpolAnalysisManager.hh
@@ -36,7 +36,8 @@ public:
   void PrepareNewEvent(const G4int evtID);
   void AddTrack(const G4Track *);
   void SetTrackAsKilled(int trackID);
-  void AddTaggedParticle(const G4Track *);
+  void AddNPOLTaggedParticle(const G4Track *);
+  void AddSHMSTaggedParticle(const G4Track *);
   void FillTree();
   void WriteObjectsToFile();
   void OpenRootFile();
@@ -58,7 +59,8 @@ private:
   TTree *npolTree;
   TFile *npolOutFile;
   std::vector<NpolVertex *> *tracks;
-  std::vector<NpolTagger *> *taggedParticles;
+  std::vector<NpolTagger *> *NPOLTaggedParticle;
+  std::vector<NpolTagger *> *SHMSTaggedParticle;
   NpolStatistics *statistics;
 };
 

--- a/include/NpolHBender.hh
+++ b/include/NpolHBender.hh
@@ -31,9 +31,12 @@ public:
   
   virtual G4String GetName();
   virtual void Place(G4LogicalVolume *motherLV);
+  void ConstructSHMSTagger();
+  void ConstructHBender();
   
 private:
-  G4LogicalVolume *HBenderLV;
+  //G4LogicalVolume *HBenderLV;
+  G4LogicalVolume *SHMSTaggerLV;
   G4LogicalVolume *HBCryoBoxLV;
   G4LogicalVolume *HBBoreLogicLV;
   G4LogicalVolume *HBCoilLogicLV;

--- a/include/NpolShieldHut.hh
+++ b/include/NpolShieldHut.hh
@@ -32,7 +32,7 @@ public:
   void ConstructHutBackWall();
   void ConstructHutRoof();
   void ConstructLeadCurtain();
-  void ConstructParticleTagger();
+  void ConstructNPOLTagger();
   
   virtual G4String GetName();
   virtual void Place(G4LogicalVolume *motherLV);
@@ -40,7 +40,7 @@ public:
 private: 
   G4LogicalVolume *HutSideWallLV, *HutFrontWallLV;
   G4LogicalVolume *HutBackWallLV, *HutRoofLV;
-  G4LogicalVolume *LeadCurtainLV, *ParticleTaggerLV;
+  G4LogicalVolume *LeadCurtainLV, *NPOLTaggerLV;
 
 };
 

--- a/src/NpolAnalysisManager.cc
+++ b/src/NpolAnalysisManager.cc
@@ -48,7 +48,8 @@ NpolAnalysisManager::NpolAnalysisManager(){
 	npolOutFile = NULL;
 	npolTree = NULL;
 	tracks = NULL;
-	taggedParticles = NULL;
+	NPOLTaggedParticle = NULL;
+	SHMSTaggedParticle = NULL;
 	statistics = NULL;
 	Initialize();
 }
@@ -72,17 +73,21 @@ void NpolAnalysisManager::Initialize(){
 
 void NpolAnalysisManager::InitializeObjects() {
 
-	statistics = new NpolStatistics();
-	statistics->version = 20151013;
-
-	tracks = new std::vector<NpolVertex *>();
-	tracks->push_back(NULL);
-	taggedParticles = new std::vector<NpolTagger *>();
-	taggedParticles->push_back(NULL);
-
-	npolTree = new TTree("T","Per-event information from Npol simulation");
-	npolTree->Branch("tracks","std::vector<NpolVertex *>",&tracks,32000,2);
-	npolTree->Branch("tagger","std::vector<NpolTagger *>",&taggedParticles,32000,2);
+  statistics = new NpolStatistics();
+  statistics->version = 20151013;
+  
+  tracks = new std::vector<NpolVertex *>();
+  tracks->push_back(NULL);
+  NPOLTaggedParticle = new std::vector<NpolTagger *>();
+  NPOLTaggedParticle->push_back(NULL);
+  
+  SHMSTaggedParticle = new std::vector<NpolTagger *>();
+  SHMSTaggedParticle->push_back(NULL);
+  
+  npolTree = new TTree("T","Per-event information from Npol simulation");
+  npolTree->Branch("tracks","std::vector<NpolVertex *>",&tracks,32000,2);
+  npolTree->Branch("SHMS_Tagger","std::vector<NpolTagger *>",&NPOLTaggedParticle,32000,2);
+  npolTree->Branch("SHMS_Tagger","std::vector<NpolTagger *>",&SHMSTaggedParticle,32000,2);
 }
 
 void NpolAnalysisManager::BeginOfRun(){
@@ -99,33 +104,38 @@ void NpolAnalysisManager::EndOfRun(){
 }
 
 void NpolAnalysisManager::PrepareNewEvent(const G4int evtID) {
+  
+  // clean out the vectors from last event
+  std::vector<NpolVertex *>::iterator it;
+  for(it = tracks->begin(); it != tracks->end(); it++)
+    delete *it;
+  
+  std::vector<NpolTagger *>::iterator it2;
+  for(it2 = NPOLTaggedParticle->begin(); it2 != NPOLTaggedParticle->end(); it2++)
+    delete *it2;
 
-	// clean out the vectors from last event
-	std::vector<NpolVertex *>::iterator it;
-	for(it = tracks->begin(); it != tracks->end(); it++)
-		delete *it;
-
-	std::vector<NpolTagger *>::iterator it2;
-	for(it2 = taggedParticles->begin(); it2 != taggedParticles->end(); it2++)
-		delete *it2;
-
-	tracks->clear();
-	taggedParticles->clear();
-
-	// maybe open a new root file
-	if((evtID % eventsPerFile == 0)/* && (evtId != 0)*/) {
-		if(npolOutFile != NULL) {
-			WriteObjectsToFile();
-			npolOutFile->Close();
-			ClearObjects();
-		}
-
-		RootFileNumber++;
-		OpenRootFile();
-		InitializeObjects();
-	}
-
-	(statistics->totalEvents)++;
+  std::vector<NpolTagger *>::iterator it3;
+  for(it3 = SHMSTaggedParticle->begin(); it3 != SHMSTaggedParticle->end(); it3++)
+    delete *it3;
+  
+  tracks->clear();
+  NPOLTaggedParticle->clear();
+  SHMSTaggedParticle->clear();
+  
+  // maybe open a new root file
+  if((evtID % eventsPerFile == 0)/* && (evtId != 0)*/) {
+    if(npolOutFile != NULL) {
+      WriteObjectsToFile();
+      npolOutFile->Close();
+      ClearObjects();
+    }
+    
+    RootFileNumber++;
+    OpenRootFile();
+    InitializeObjects();
+  }
+  
+  (statistics->totalEvents)++;
 }
 
 void NpolAnalysisManager::AddTrack(const G4Track *aTrack) {
@@ -163,106 +173,125 @@ void NpolAnalysisManager::AddTrack(const G4Track *aTrack) {
 }
 
 void NpolAnalysisManager::SetTrackAsKilled(int trackId) {
-	(*tracks)[trackId]->eMiss = true;
+  (*tracks)[trackId]->eMiss = true;
 }
 
-void NpolAnalysisManager::AddTaggedParticle(const G4Track *aTrack) {
-	NpolTagger *anNpolTaggedParticle = new NpolTagger();
+void NpolAnalysisManager::AddNPOLTaggedParticle(const G4Track *aTrack) {
+  NpolTagger *anNpolTaggedParticle = new NpolTagger();
+  
+  anNpolTaggedParticle->trackId = aTrack->GetTrackID();
+  anNpolTaggedParticle->posX = (aTrack->GetPosition()).x()/m;
+  anNpolTaggedParticle->posY = (aTrack->GetPosition()).y()/m;
+  anNpolTaggedParticle->posZ = (aTrack->GetPosition()).z()/m;
+  anNpolTaggedParticle->momX = (aTrack->GetMomentum()).x()/MeV;
+  anNpolTaggedParticle->momY = (aTrack->GetMomentum()).y()/MeV;
+  anNpolTaggedParticle->momZ = (aTrack->GetMomentum()).z()/MeV;
+  anNpolTaggedParticle->time = (aTrack->GetGlobalTime())/s;
+  anNpolTaggedParticle->energy = aTrack->GetKineticEnergy()/MeV;
+  anNpolTaggedParticle->particle = (aTrack->GetDefinition()->GetParticleName()).data();
+  anNpolTaggedParticle->particleId = (aTrack->GetDefinition()->GetPDGEncoding());
+  
+  NPOLTaggedParticle->push_back(anNpolTaggedParticle);
+}
 
-	anNpolTaggedParticle->trackId = aTrack->GetTrackID();
-	anNpolTaggedParticle->posX = (aTrack->GetPosition()).x()/m;
-	anNpolTaggedParticle->posY = (aTrack->GetPosition()).y()/m;
-	anNpolTaggedParticle->posZ = (aTrack->GetPosition()).z()/m;
-	anNpolTaggedParticle->momX = (aTrack->GetMomentum()).x()/MeV;
-	anNpolTaggedParticle->momY = (aTrack->GetMomentum()).y()/MeV;
-	anNpolTaggedParticle->momZ = (aTrack->GetMomentum()).z()/MeV;
-	anNpolTaggedParticle->time = (aTrack->GetGlobalTime())/s;
-	anNpolTaggedParticle->energy = aTrack->GetKineticEnergy()/MeV;
-	anNpolTaggedParticle->particle = (aTrack->GetDefinition()->GetParticleName()).data();
-	anNpolTaggedParticle->particleId = (aTrack->GetDefinition()->GetPDGEncoding());
-
-	taggedParticles->push_back(anNpolTaggedParticle);
+void NpolAnalysisManager::AddSHMSTaggedParticle(const G4Track *aTrack) {
+  NpolTagger *anSHMSTaggedParticle = new NpolTagger();
+  
+  anSHMSTaggedParticle->trackId = aTrack->GetTrackID();
+  anSHMSTaggedParticle->posX = (aTrack->GetPosition()).x()/m;
+  anSHMSTaggedParticle->posY = (aTrack->GetPosition()).y()/m;
+  anSHMSTaggedParticle->posZ = (aTrack->GetPosition()).z()/m;
+  anSHMSTaggedParticle->momX = (aTrack->GetMomentum()).x()/MeV;
+  anSHMSTaggedParticle->momY = (aTrack->GetMomentum()).y()/MeV;
+  anSHMSTaggedParticle->momZ = (aTrack->GetMomentum()).z()/MeV;
+  anSHMSTaggedParticle->time = (aTrack->GetGlobalTime())/s;
+  anSHMSTaggedParticle->energy = aTrack->GetKineticEnergy()/MeV;
+  anSHMSTaggedParticle->particle = (aTrack->GetDefinition()->GetParticleName()).data();
+  anSHMSTaggedParticle->particleId = (aTrack->GetDefinition()->GetPDGEncoding());
+  
+  SHMSTaggedParticle->push_back(anSHMSTaggedParticle);
 }
 
 void NpolAnalysisManager::FillTree() {
 
-	// This portion of code checks to see if the vector has any daughters at
-	// all if it doesn't it does not fill the tree.  If it does then it 
-	// checks to see if at least one is in an assembly volume which is 
-	// part of the polarimeter.  If it is then it fills the tree, otherwise,
-	// it skips filling and the next event is generated.  Cuts down on space 
-	// used in the files from the majority of events which do not produce events
-	// in the polarimeter.
-
-	std::vector<NpolVertex *>::iterator it;
-	for(it = tracks->begin(); it != tracks->end(); it++){
-
-		if(*it == NULL) continue;
-		G4String volName = (*it)->volume;
-
-		if(!((*it)->daughterIds).empty()){
-			G4String subVolName = volName.substr(0,3).c_str();
-			if(subVolName == "av_"){
-				npolTree->Fill();
-				(statistics->eventsSaved)++;
-				break;
-			}
-		}
-	}
+  // This portion of code checks to see if the vector has any daughters at
+  // all if it doesn't it does not fill the tree.  If it does then it 
+  // checks to see if at least one is in an assembly volume which is 
+  // part of the polarimeter.  If it is then it fills the tree, otherwise,
+  // it skips filling and the next event is generated.  Cuts down on space 
+  // used in the files from the majority of events which do not produce events
+  // in the polarimeter.
+  
+  std::vector<NpolVertex *>::iterator it;
+  for(it = tracks->begin(); it != tracks->end(); it++){
+    
+    if(*it == NULL) continue;
+    G4String volName = (*it)->volume;
+    
+    if(!((*it)->daughterIds).empty()){
+      G4String subVolName = volName.substr(0,3).c_str();
+      if(subVolName == "av_"){
+	npolTree->Fill();
+	(statistics->eventsSaved)++;
+	break;
+      }
+    }
+  }
 }
 
 void NpolAnalysisManager::WriteObjectsToFile() {
-	npolTree->Write();
-	statistics->Write();
+  npolTree->Write();
+  statistics->Write();
 }
 
 void NpolAnalysisManager::OpenRootFile() {
-
-	G4String fileName = Form("%s/%s_%s_%04d.root", dirName.c_str(), rootName.c_str(), jobNumber.c_str(), RootFileNumber);
-	npolOutFile = new TFile(fileName,"RECREATE");
-
-	if( npolOutFile->IsZombie() ) {
-		G4cerr << "------- File " << fileName << "  could not be opened. " << G4endl;
-		G4cerr << "             " << " Does the directory '" << dirName << "/' exist?" << G4endl;
-		exit(0);
-	}
-	G4cout << "------- File " << fileName << " has been opened. " << G4endl;
+  
+  G4String fileName = Form("%s/%s_%s_%04d.root", dirName.c_str(), rootName.c_str(), jobNumber.c_str(), RootFileNumber);
+  npolOutFile = new TFile(fileName,"RECREATE");
+  
+  if( npolOutFile->IsZombie() ) {
+    G4cerr << "------- File " << fileName << "  could not be opened. " << G4endl;
+    G4cerr << "             " << " Does the directory '" << dirName << "/' exist?" << G4endl;
+    exit(0);
+  }
+  G4cout << "------- File " << fileName << " has been opened. " << G4endl;
 }
 
 void NpolAnalysisManager::setFileName(const G4String& nam) {
-	rootName = nam;
+  rootName = nam;
 }
 
 void NpolAnalysisManager::ClearObjects(){  
-	npolOutFile = NULL;
-	npolTree = NULL;
-	tracks = NULL;
-	taggedParticles = NULL;
-	if(statistics != NULL) {
-		statistics->totalEvents = 0;
-		statistics->eventsSaved = 0;
-	}
+  npolOutFile = NULL;
+  npolTree = NULL;
+  tracks = NULL;
+  NPOLTaggedParticle = NULL;
+  SHMSTaggedParticle = NULL;
+  if(statistics != NULL) {
+    statistics->totalEvents = 0;
+    statistics->eventsSaved = 0;
+  }
 }
 
 void NpolAnalysisManager::InitializeFilenameVariables(){
-	if(getenv("NPOLBASENAME")){
-		rootName = getenv("NPOLBASENAME");
-	}else{
-		rootName = "npol"; // default filename
-	}
-
-	if(getenv("NPOLDIR")){
-		dirName = getenv("NPOLDIR");
-	}else{
-		dirName = "output"; // default directory location
-	}
-
-	if(getenv("JOBNUMBER")){
-		jobNumber = getenv("JOBNUMBER");
-	}else{
-		jobNumber = "99999";
-	}
-
-	RootFileNumber = 0;
+  if(getenv("NPOLBASENAME")){
+    rootName = getenv("NPOLBASENAME");
+  }else{
+    rootName = "npol"; // default filename
+  }
+  
+  if(getenv("NPOLDIR")){
+    dirName = getenv("NPOLDIR");
+  }else{
+    dirName = "output"; // default directory location
+  }
+  
+  if(getenv("JOBNUMBER")){
+    jobNumber = getenv("JOBNUMBER");
+  }else{
+    jobNumber = "99999";
+  }
+  
+  RootFileNumber = 0;
 }
 

--- a/src/NpolHBender.cc
+++ b/src/NpolHBender.cc
@@ -26,20 +26,36 @@
 #include "NpolHBender.hh"
 
 NpolHBender::NpolHBender() {
+  ConstructHBender();
+  ConstructSHMSTagger();
+}
+
+NpolHBender::~NpolHBender() {}
+
+void NpolHBender::ConstructSHMSTagger(){
+  G4double xlen = 0.1588*m; G4double ylen = 0.2075*m; G4double zlen = 0.010*cm;
+  
+  G4Box *SHMSTagger = new G4Box("SHMSTagger",xlen/2,ylen/2,zlen/2);
+  SHMSTaggerLV = new G4LogicalVolume(SHMSTagger,NpolMaterials::GetInstance()->GetAir(),"SHMSTaggerLV",0,0,0);
+  G4VisAttributes *TaggerVisAtt = new G4VisAttributes(G4Colour(0.2, 0.2, 0.2));
+  SHMSTaggerLV->SetVisAttributes(TaggerVisAtt);
+}
+
+void NpolHBender::ConstructHBender(){
   G4GDMLParser parser;
   
   G4String gdmlFilename = "gdml/HBender.gdml";
   parser.Read(gdmlFilename);
-
+  
   //HBenderLV = parser.GetVolume("HBenderPV");
   HBCryoBoxLV = parser.GetVolume("HBCryoBoxLogic");  
   HBBoreLogicLV = parser.GetVolume("HBBoreLogic");
   HBCoilLogicLV = parser.GetVolume("HBCoilLogic");
   HBYorkLogicLV = parser.GetVolume("HBYorkLogic");
   
-   //G4VisAttributes *VisAtt= new G4VisAttributes(G4Colour(0.0,0.0,1.0));
+  //G4VisAttributes *VisAtt= new G4VisAttributes(G4Colour(0.0,0.0,1.0));
   //HBenderLV->SetVisAttributes(VisAtt);
-  HBenderLV->SetVisAttributes(G4VisAttributes::GetInvisible());
+  //HBenderLV->SetVisAttributes(G4VisAttributes::GetInvisible());
   
   G4VisAttributes *VisAtt= new G4VisAttributes(G4Colour(1.0,0.0,1.0));
   HBCryoBoxLV->SetVisAttributes(VisAtt);
@@ -48,20 +64,19 @@ NpolHBender::NpolHBender() {
   HBBoreLogicLV->SetVisAttributes(VisAtt);
 }
 
-NpolHBender::~NpolHBender() {}
-
 G4String NpolHBender::GetName() {
   return G4String("Horizontal Bender");
 }
 
 void NpolHBender::Place(G4LogicalVolume *motherLV) {
-  G4double ShmsAng = 0.0*deg; // Angle at 4.4 GeV/c 36.53*deg; 
-  G4double PosHB = 1.76*m;
+  G4double ShmsAng = 36.53*deg; // Angle at 4.4 GeV/c 36.53*deg; 
+  G4double PosHB = 1.76*m, PosTagger = 1.195*m;
   
   //PlaceCylindrical(HBenderLV,motherLV, "HBender", PosHB, ShmsAng, 0);
   PlaceCylindrical(HBBoreLogicLV, motherLV, "HBBore", PosHB, ShmsAng, 0);
   //PlaceCylindrical(HBCoilLogicLV, motherLV, "HBCoil", PosHB, ShmsAng, 0);
   PlaceCylindrical(HBYorkLogicLV, motherLV, "HBYork", PosHB, ShmsAng, 0);
   PlaceCylindrical(HBCryoBoxLV, motherLV, "HBCyro", PosHB, ShmsAng, 0);
+  PlaceRectangular(SHMSTaggerLV,motherLV, "SHMSTagger", (PosTagger+4.0*cm)*sin(ShmsAng), 0.0, (PosTagger-4.0*cm)*cos(ShmsAng), 0.0, ShmsAng, 0.0);
 } 
 

--- a/src/NpolHBender.cc
+++ b/src/NpolHBender.cc
@@ -21,7 +21,7 @@
 #include "G4Colour.hh"
 #include "G4ios.hh"
 #include "G4GDMLParser.hh"
-
+#include "G4tgbGeometryDumper.hh" 
 #include "NpolMaterials.hh"
 #include "NpolHBender.hh"
 
@@ -31,13 +31,13 @@ NpolHBender::NpolHBender() {
   G4String gdmlFilename = "gdml/HBender.gdml";
   parser.Read(gdmlFilename);
 
-  HBenderLV = parser.GetVolume("HBenderPV");
+  //HBenderLV = parser.GetVolume("HBenderPV");
   HBCryoBoxLV = parser.GetVolume("HBCryoBoxLogic");  
   HBBoreLogicLV = parser.GetVolume("HBBoreLogic");
   HBCoilLogicLV = parser.GetVolume("HBCoilLogic");
   HBYorkLogicLV = parser.GetVolume("HBYorkLogic");
   
-  //G4VisAttributes *VisAtt= new G4VisAttributes(G4Colour(0.0,0.0,1.0));
+   //G4VisAttributes *VisAtt= new G4VisAttributes(G4Colour(0.0,0.0,1.0));
   //HBenderLV->SetVisAttributes(VisAtt);
   HBenderLV->SetVisAttributes(G4VisAttributes::GetInvisible());
   
@@ -55,13 +55,13 @@ G4String NpolHBender::GetName() {
 }
 
 void NpolHBender::Place(G4LogicalVolume *motherLV) {
-  G4double ShmsAng = 36.53*deg;
+  G4double ShmsAng = 0.0*deg; // Angle at 4.4 GeV/c 36.53*deg; 
   G4double PosHB = 1.76*m;
   
   //PlaceCylindrical(HBenderLV,motherLV, "HBender", PosHB, ShmsAng, 0);
   PlaceCylindrical(HBBoreLogicLV, motherLV, "HBBore", PosHB, ShmsAng, 0);
-  PlaceCylindrical(HBCoilLogicLV, motherLV, "HBCoil", PosHB, ShmsAng, 0);
-  PlaceCylindrical(HBCoilLogicLV, motherLV, "HBYork", PosHB, ShmsAng, 0);
+  //PlaceCylindrical(HBCoilLogicLV, motherLV, "HBCoil", PosHB, ShmsAng, 0);
+  PlaceCylindrical(HBYorkLogicLV, motherLV, "HBYork", PosHB, ShmsAng, 0);
   PlaceCylindrical(HBCryoBoxLV, motherLV, "HBCyro", PosHB, ShmsAng, 0);
 } 
 

--- a/src/NpolShieldHut.cc
+++ b/src/NpolShieldHut.cc
@@ -31,7 +31,7 @@ NpolShieldHut::NpolShieldHut() {
   ConstructHutBackWall();
   ConstructHutSideWall();
   ConstructHutRoof();
-  ConstructParticleTagger();
+  ConstructNPOLTagger();
   ConstructLeadCurtain();
 }
 
@@ -52,13 +52,13 @@ void NpolShieldHut::ConstructLeadCurtain(){
 }
 
 // Construct a thin air box so we can tag particles passing through the collimator.  Place it just a millimeter off the front steel wall
-void NpolShieldHut::ConstructParticleTagger(){
+void NpolShieldHut::ConstructNPOLTagger(){
   G4double xlen = 1.0*m; G4double ylen = 0.80*m; G4double zlen = 0.010*cm;
 
-  G4Box *ParticleTagger = new G4Box("ParticleTagger",xlen/2,ylen/2,zlen/2);
-  ParticleTaggerLV = new G4LogicalVolume(ParticleTagger,NpolMaterials::GetInstance()->GetAir(),"ParticleTaggerLV",0,0,0);
-  G4VisAttributes *ParticleTaggerVisAtt = new G4VisAttributes(G4Colour(0.2, 0.2, 0.2));
-  ParticleTaggerLV->SetVisAttributes(ParticleTaggerVisAtt);
+  G4Box *NPOLTagger = new G4Box("NPOLTagger",xlen/2,ylen/2,zlen/2);
+  NPOLTaggerLV = new G4LogicalVolume(NPOLTagger,NpolMaterials::GetInstance()->GetAir(),"NPOLTaggerLV",0,0,0);
+  G4VisAttributes *TaggerVisAtt = new G4VisAttributes(G4Colour(0.2, 0.2, 0.2));
+  NPOLTaggerLV->SetVisAttributes(TaggerVisAtt);
 }
 
 // Construct the front wall of the shield hut from 4 ft by 4 ft by 3 ft blocks
@@ -130,7 +130,7 @@ void NpolShieldHut::Place(G4LogicalVolume *motherLV) {
   G4double PosFront = 6.2739*m, PosBack = 11.7739*m, PosRoof = 9.0239*m, OffSetRoof = 3.7776*m, PosLead = PosFront - 0.48*m, PosTagger = PosFront + 0.51*m;
 
   PlaceCylindrical(LeadCurtainLV, motherLV, "LeadCurtain", PosLead,-NpolAng, 0);
-  PlaceCylindrical(ParticleTaggerLV, motherLV, "ParticleTagger", PosTagger, -NpolAng, 0);
+  PlaceCylindrical(NPOLTaggerLV, motherLV, "NPOLTagger", PosTagger, -NpolAng, 0);
   PlaceCylindrical(HutFrontWallLV, motherLV, "HutFrontWall", PosFront,-NpolAng,-VertOffSet);
   PlaceCylindrical(HutBackWallLV, motherLV, "HutBackWall", PosBack,-NpolAng,-VertOffSet);
   PlaceRectangular(HutSideWallLV, motherLV, "HutSideWall", -PosSide*sin(AngSide+NpolAng), -VertOffSet, PosSide*cos(AngSide+NpolAng), 0*deg, -NpolAng, 0*deg);

--- a/src/NpolSteppingAction.cc
+++ b/src/NpolSteppingAction.cc
@@ -30,7 +30,7 @@ NpolSteppingAction::NpolSteppingAction(NpolEventAction* evt, NpolRunAction* run)
 
 NpolSteppingAction::~NpolSteppingAction() 
 {
-  G4cout<< "Ending NpolSteppingAction" << G4endl;
+  G4cout<< "Shutting Down Stepping Action" << G4endl;
 }
 
 void NpolSteppingAction::UserSteppingAction(const G4Step *aStep) {
@@ -48,8 +48,7 @@ void NpolSteppingAction::UserSteppingAction(const G4Step *aStep) {
 	aTrack->SetTrackStatus(fStopAndKill);
   }
 
-  if((preStepVolume->GetName() == "ParticleTagger")){
-    analysisMan->AddTaggedParticle(aTrack);
-  }
+  if(volName == "NpolTagger") analysisMan->AddNPOLTaggedParticle(aTrack);
+  if(volName == "SHMSTagger") analysisMan->AddSHMSTaggedParticle(aTrack);
 }
 


### PR DESCRIPTION
Attempted to fix the warnings receved from the horizonatl bender magnet.  Narrowed it down to the coil which appears to be having some problems with the subtraction volumes.  The strange part is there are no overlaps with other placed volumes.  Instead it throws errors with the subtraction volumes.  Needs a bit more investigation.  Currently, the coil is NOT placed.  This is a simplficaiton of the model but given the background in the polarimeter is most likely from the target area and only secondary "stuff" from beamline and the steel portions of the H-Bender magnet I am confident this will be fine.  

I also added to the Horizontal bender a SHMS tagger element in the front of the SHMS entrance for use in taking particles in particular for coincidence tests.  Updated Stepping action and analysis manager to output this information into a new branch.  Renamed the methods for the Npol Tagger and SHMS to make more sense.  