### PR TITLE
Added ParentID and particleID to the NpolStep.hh class plus added Par…

### DIFF
--- a/npollib/include/NpolStep.hh
+++ b/npollib/include/NpolStep.hh
@@ -18,6 +18,7 @@ class NpolStep : public TObject {
 
 public:
   int trackId;
+  int parentId;
   double gPosX;
   double gPosY;
   double gPosZ;
@@ -29,6 +30,7 @@ public:
   double momZ;
   double time;
   double eDep;
+  int  particleId;
   std::string volume;
 
   inline NpolStep() {};

--- a/npollib/include/NpolTagger.hh
+++ b/npollib/include/NpolTagger.hh
@@ -19,6 +19,7 @@ class NpolTagger : public TObject {
 public:
 
   int trackId;
+  int parentId;
   double gPosX;
   double gPosY;
   double gPosZ;

--- a/simulation/src/NpolAnalysisManager.cc
+++ b/simulation/src/NpolAnalysisManager.cc
@@ -21,7 +21,7 @@
 #include "NpolTagger.hh"
 #include "NpolStatistics.hh"
 
-#define OUTFILE_VERSION 20160504 // Determined by YYYYMMDD
+#define OUTFILE_VERSION 20170309 // Determined by YYYYMMDD
 
 NpolAnalysisManager *NpolAnalysisManager::pInstance = NULL;
 
@@ -186,6 +186,7 @@ void NpolAnalysisManager::RecordStep(const G4Step *aStep) {
     	NpolStep *npolStep = new NpolStep();
 		
 		npolStep->trackId = aTrack->GetTrackID();
+		npolStep->parentId = aTrack->GetParentID();
 		npolStep->gPosX = worldPosition.x()/cm;
 		npolStep->gPosY = worldPosition.y()/cm;
 		npolStep->gPosZ = worldPosition.z()/cm;
@@ -197,6 +198,7 @@ void NpolAnalysisManager::RecordStep(const G4Step *aStep) {
 		npolStep->momZ = (aTrack->GetMomentum()).z()/cm;
 		npolStep->time = aTrack->GetGlobalTime()/ns;
 		npolStep->eDep = (aStep->GetTotalEnergyDeposit())/MeV;
+		npolStep->particleId = aTrack->GetDefinition()->GetPDGEncoding();
 		npolStep->volume = volName;
 		steps->push_back(npolStep);
 	}
@@ -210,6 +212,7 @@ void NpolAnalysisManager::RecordStep(const G4Step *aStep) {
 		NpolTagger *taggedParticle = new NpolTagger();
 
 		taggedParticle->trackId = aTrack->GetTrackID();
+		taggedParticle->parentId = aTrack->GetParentID();
 		taggedParticle->gPosX = worldPosition.x()/cm;
 		taggedParticle->gPosY = worldPosition.y()/cm;
 		taggedParticle->gPosZ = worldPosition.z()/cm;


### PR DESCRIPTION
…entID to the NpolTagger.hh Class.  NpolAnalysisManager.hh now writes these out into the ROOT file.  These, I found, are going to be necessary to properly analyze the particle flux on the vetos and analyzers.